### PR TITLE
Chdir to the application directory before starting

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -42,7 +42,8 @@ action :create do
                 environment:    new_resource.environment,
                 locale:         new_resource.locale,
                 user:           new_resource.user,
-                service_name:   new_resource.service_name
+                service_name:   new_resource.service_name,
+                app_root:       new_resource.rails_root
     else
       variables new_resource.variables
     end

--- a/templates/ubuntu/unicorn.init.erb
+++ b/templates/ubuntu/unicorn.init.erb
@@ -15,6 +15,7 @@ export BUNDLE_GEMFILE="<%= @bundle_gemfile %>"
 SHELL=/bin/bash
 DAEMON="<%= @bundle %>"
 DAEMON_OPTS="exec unicorn -D -E <%= @environment %> -c <%= @config %>"
+APP_ROOT="<%= @app_root %>"
 
 <% if @wrapper %>
 WRAPPER="<%= @wrapper %>"
@@ -54,7 +55,7 @@ case "$1" in
       exit 0
     fi
 
-    if start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER --exec $COMMAND; then
+    if start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER --chdir $APP_ROOT --exec $COMMAND; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false


### PR DESCRIPTION
This fixed an issue where unicorn 4.7.0 blew up because it couldn't find
the `config.ru` file on Ubuntu 12.04 LTS.

System info:
- ruby 2.0.0p353 (2013-11-22 revision 43784) [x86_64-linux]
- unicorn v4.7.0
- 3.8.0-35-generic #50~precise1-Ubuntu SMP Wed Dec 4 17:25:51 UTC 2013 x86_64
