### PR TITLE
Add support for systems that do not use rubygems.

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -27,6 +27,7 @@ default['unicorn-ng']['config']['timeout'] = 60
 default['unicorn-ng']['config']['stderr_path'] = 'log/unicorn.stderr.log'
 default['unicorn-ng']['config']['stdout_path'] = 'log/unicorn.stdout.log'
 default['unicorn-ng']['config']['preload_app'] = true
+default['unicorn-ng']['config']['install_rubygems'] = true
 
 # When sent a USR2, Unicorn will suffix its pidfile with .oldbin and
 # immediately start loading up a new version of itself (loaded with a new

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-package 'rubygems'
+package 'rubygems' if node['unicorn-ng']['config']['install_rubygems']
 
 gem_package 'bundler'
 gem_package 'unicorn'


### PR DESCRIPTION
A lot of modern environments like ubuntu 14.04 don't have a Rubygems package. This patch allows users to use the cookbook without Rubygems in such situations. The default behavior is unchanged.
