### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ default['unicorn-ng']['service']['rails_root'] = '/var/www/example.com'
 The following attributes will be set automatically relative to the rails_root, if not specified.
 
 ```ruby
-default['unicorn-ng']['service']['unicorn_config'] = nil
+default['unicorn-ng']['service']['config'] = nil
 default['unicorn-ng']['service']['bundle_gemfile'] = nil
 default['unicorn-ng']['service']['pidfile'] = nil
 ```


### PR DESCRIPTION
corrected
default['unicorn-ng']['service']['unicorn_config']
to `default['unicorn-ng']['service']['config']

in providers you ask for config so I corrected this in your Readme.

Took me a while to figure this out. I hope this helps others to avoid this problem.
