### PR TITLE
Do not use sudo when not necessary

### DIFF
--- a/templates/ubuntu/unicorn.init.erb
+++ b/templates/ubuntu/unicorn.init.erb
@@ -25,7 +25,12 @@ COMMAND="$DAEMON -- $DAEMON_OPTS"
 <% end -%>
 
 PIDFILE="<%= @pidfile %>"
-USER="<%= @user %>"
+if [ $USER"x" = "<%= @user %>x" ]
+then
+  CHUID=""
+else
+  CHUID="--chuid <%= @user %>"
+fi
 LANG="<%= @locale %>"
 LC_ALL="<%= @locale %>"
 LANGUAGE="<%= @locale %>"
@@ -54,7 +59,7 @@ case "$1" in
       exit 0
     fi
 
-    if start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER --exec $COMMAND; then
+    if start-stop-daemon --start --quiet --pidfile $PIDFILE $CHUID --exec $COMMAND; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false
@@ -64,7 +69,7 @@ case "$1" in
   stop)
     log_daemon_msg "Stopping $NAME" || true
 
-    if start-stop-daemon --stop --quiet --pidfile $PIDFILE --chuid $USER; then
+    if start-stop-daemon --stop --quiet --pidfile $PIDFILE $CHUID; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false
@@ -77,7 +82,7 @@ case "$1" in
 
       # send SIGUSR2 to duplicate unicorn
       # before_fork will take care of qutting the old one
-      if start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE --chuid $USER; then
+      if start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE $CHUID; then
         log_end_msg 0 || true
       else
         log_end_msg 1 || false
@@ -98,7 +103,7 @@ case "$1" in
     # send SIGHUP to gracefully restart all workers
     log_daemon_msg "Reloading $NAME" || true
 
-    if start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --chuid $USER; then
+    if start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE $CHUID; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false
@@ -109,7 +114,7 @@ case "$1" in
     # send SIGTTIN to tell unicorn to spawn an additional worker
     log_daemon_msg "Adding one $NAME worker" || true
 
-    if start-stop-daemon --stop --signal TTIN --quiet --pidfile $PIDFILE --chuid $USER; then
+    if start-stop-daemon --stop --signal TTIN --quiet --pidfile $PIDFILE $CHUID; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false
@@ -120,7 +125,7 @@ case "$1" in
     # send SIGTTOU to tell unicorn to stop one worker
     log_daemon_msg "Removing one $NAME worker" || true
 
-    if start-stop-daemon --stop --signal TTOU --quiet --pidfile $PIDFILE --chuid $USER; then
+    if start-stop-daemon --stop --signal TTOU --quiet --pidfile $PIDFILE $CHUID; then
       log_end_msg 0 || true
     else
       log_end_msg 1 || false


### PR DESCRIPTION
This allows the script to not use sudo when not-necessary (ie: when the running user is the same than the user for the script)

This is because start-stop-daemon uses sudo when --chuid option is passed (but it's not necessary if the user is the same)
