### PR TITLE
Fix update resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Gemfile.lock
 .kitchen
 bin
 .kitchen.local.yml
+/.idea/
+*.iml

--- a/providers/config.rb
+++ b/providers/config.rb
@@ -18,8 +18,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+use_inline_resources
 action :create do
-  r = template new_resource.path do
+  template new_resource.path do
     owner     new_resource.owner
     group     new_resource.group
     mode      new_resource.mode
@@ -43,6 +44,4 @@ action :create do
       variables new_resource.variables
     end
   end
-
-  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 end

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
+use_inline_resources
 action :create do
-  r = template "/etc/init.d/#{new_resource.service_name}" do
+  template "/etc/init.d/#{new_resource.service_name}" do
     owner new_resource.owner
     group new_resource.group
     mode  new_resource.mode
@@ -47,8 +47,6 @@ action :create do
       variables new_resource.variables
     end
   end
-
-  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 
   service new_resource.service_name do
     supports restart: true, status: true, reload: true


### PR DESCRIPTION
This is not correct, because in this line resource `r` defined but action for it is  not running, and resource is not updated. As a consequence, even if the config file is updated, the notification for the `unicorn_ng_config` resource does not triggered. The same problem with` unicorn_ng_service`.

     new_resource.updated_by_last_action(true) if r.updated_by_last_action?

